### PR TITLE
Don't fire PageView twice on load

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -11,7 +11,6 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
 },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
 a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
   twq('init', '${pluginOptions.pixelId}'); // Insert your pixel ID here.
-  twq('track', 'PageView');
       `,
         }}
       />,


### PR DESCRIPTION
Previously the PageView event was fired twice - on page load, and on route update (which happens right after page load).

Removing it from the SSR ensures it won't be fired until the route update event, and will only happen once.