### PR TITLE
Replace PageView event with ViewContent. 

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,6 +1,6 @@
 exports.onRouteUpdate = function({ location }) {
   // Don't track while developing.
   if (process.env.NODE_ENV === `production` && typeof twq === `function`) {
-    twq('track', 'PageView');
+    twq('track', 'ViewContent');
   }
 };


### PR DESCRIPTION
Today we are calling PageView event twice: on SPA loading and on route change. We should call PageView event on SPA load and ViewContent on route change. See how it works on gatsby facebook pixel plugin https://github.com/gabefromutah/gatsby-plugin-facebook-pixel/blob/master/src/gatsby-browser.js